### PR TITLE
feature-category

### DIFF
--- a/only4-KSP-cap4j-application/src/main/java/com/only4/application/commands/category/DeleteCategoryCmd.java
+++ b/only4-KSP-cap4j-application/src/main/java/com/only4/application/commands/category/DeleteCategoryCmd.java
@@ -1,8 +1,8 @@
 package com.only4.application.commands.category;
 
 
-import com.only4.domain.aggregates.article.ArticleCategory;
-import com.only4.domain.aggregates.article.meta.ArticleCategorySchema;
+import com.only4.application.validater.category.CategoryExists;
+import com.only4.application.validater.category.CategoryNotRef;
 import com.only4.domain.aggregates.category.Category;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
@@ -52,28 +52,10 @@ public class DeleteCategoryCmd {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Request implements RequestParam<Response> {
+
+        @CategoryExists
+        @CategoryNotRef
         Long categoryId;
-
-        {
-            validateCategoryExists();
-            validateCategoryHasNoArticles();
-        }
-
-        private void validateCategoryExists() {
-            if (!Mediator.repositories().exists(JpaPredicate.byId(Category.class, categoryId))) {
-                throw new IllegalArgumentException("分类不存在");
-            }
-        }
-
-        private void validateCategoryHasNoArticles() {
-            if (Mediator.repositories().exists(JpaPredicate.bySpecification(ArticleCategory.class,
-                    ArticleCategorySchema.specify(articleCategory ->
-                            articleCategory.categoryId().eq(categoryId)
-                    ))
-            )) {
-                throw new IllegalArgumentException("分类下存在文章，无法删除");
-            }
-        }
     }
 
     /**

--- a/only4-KSP-cap4j-application/src/main/java/com/only4/application/commands/category/UpdateCategoryInfoCmd.java
+++ b/only4-KSP-cap4j-application/src/main/java/com/only4/application/commands/category/UpdateCategoryInfoCmd.java
@@ -1,8 +1,9 @@
 package com.only4.application.commands.category;
 
 
+import com.only4.application.validater.category.CategoryExists;
+import com.only4.application.validater.category.CategoryNotExistsWithName;
 import com.only4.domain.aggregates.category.Category;
-import com.only4.domain.aggregates.category.meta.CategorySchema;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.netcorepal.cap4j.ddd.Mediator;
@@ -51,28 +52,12 @@ public class UpdateCategoryInfoCmd {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Request implements RequestParam<Response> {
+
+        @CategoryExists
         Long categoryId;
+
+        @CategoryNotExistsWithName
         String categoryName;
-
-        {
-            validateCategoryExists();
-            validateCategoryNameNotExists();
-        }
-
-        private void validateCategoryExists() {
-            if (!Mediator.repositories().exists(JpaPredicate.byId(Category.class, categoryId))) {
-                throw new IllegalArgumentException("分类不存在");
-            }
-        }
-
-        private void validateCategoryNameNotExists() {
-            if (Mediator.repositories().exists(JpaPredicate.bySpecification(Category.class,
-                    CategorySchema.specify(category -> category.name().equal(categoryName)
-                    ))
-            )) {
-                throw new IllegalArgumentException("分类名称已存在");
-            }
-        }
     }
 
     /**

--- a/only4-KSP-cap4j-application/src/main/java/com/only4/application/validater/category/CategoryExists.java
+++ b/only4-KSP-cap4j-application/src/main/java/com/only4/application/validater/category/CategoryExists.java
@@ -1,0 +1,34 @@
+package com.only4.application.validater.category;
+
+import com.only4.application.validater.article.ArticleExists;
+import com.only4.domain.aggregates.article.Article;
+import com.only4.domain.aggregates.category.Category;
+import org.netcorepal.cap4j.ddd.Mediator;
+import org.netcorepal.cap4j.ddd.domain.repo.JpaPredicate;
+
+import javax.validation.Constraint;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = {ElementType.FIELD})
+@Constraint(validatedBy = CategoryExists.Validator.class)
+public @interface CategoryExists {
+    String message() default "分类不存在";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    class Validator implements ConstraintValidator<CategoryExists, Long> {
+        @Override
+        public boolean isValid(Long categoryId, ConstraintValidatorContext context) {
+            return Mediator.repositories().exists(JpaPredicate.byId(Category.class, categoryId));
+        }
+    }
+}

--- a/only4-KSP-cap4j-application/src/main/java/com/only4/application/validater/category/CategoryNotExistsWithName.java
+++ b/only4-KSP-cap4j-application/src/main/java/com/only4/application/validater/category/CategoryNotExistsWithName.java
@@ -1,0 +1,39 @@
+package com.only4.application.validater.category;
+
+import com.only4.domain.aggregates.article.Article;
+import com.only4.domain.aggregates.category.Category;
+import com.only4.domain.aggregates.category.meta.CategorySchema;
+import org.netcorepal.cap4j.ddd.Mediator;
+import org.netcorepal.cap4j.ddd.domain.repo.JpaPredicate;
+
+import javax.validation.Constraint;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = {ElementType.FIELD})
+@Constraint(validatedBy = CategoryNotExistsWithName.Validator.class)
+public @interface CategoryNotExistsWithName {
+    String message() default "同名标签已存在";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    class Validator implements ConstraintValidator<CategoryNotExistsWithName, String> {
+        @Override
+        public boolean isValid(String categoryName, ConstraintValidatorContext context) {
+            return !Mediator.repositories()
+                    .exists(JpaPredicate.bySpecification(Category.class,
+                            CategorySchema.specify(category ->
+                                    category.name().equal(categoryName)
+                            )
+                    ));
+        }
+    }
+}

--- a/only4-KSP-cap4j-application/src/main/java/com/only4/application/validater/category/CategoryNotRef.java
+++ b/only4-KSP-cap4j-application/src/main/java/com/only4/application/validater/category/CategoryNotRef.java
@@ -1,0 +1,36 @@
+package com.only4.application.validater.category;
+
+import com.only4.domain.aggregates.category.Category;
+import org.netcorepal.cap4j.ddd.Mediator;
+import org.netcorepal.cap4j.ddd.domain.repo.JpaPredicate;
+
+import javax.validation.Constraint;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = {ElementType.FIELD})
+@Constraint(validatedBy = CategoryNotRef.Validator.class)
+public @interface CategoryNotRef {
+
+    String message() default "分类不存在";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    class Validator implements ConstraintValidator<CategoryNotRef, Long> {
+        @Override
+        public boolean isValid(Long categoryId, ConstraintValidatorContext context) {
+            return Mediator.repositories()
+                    .findOne(JpaPredicate.byId(Category.class, categoryId))
+                    .map(category -> category.getRefCount() == 0)
+                    .orElseThrow(() -> new IllegalArgumentException("RefCount异常"));
+        }
+    }
+}

--- a/only4-KSP-cap4j-domain/src/main/java/com/only4/domain/aggregates/category/Category.java
+++ b/only4-KSP-cap4j-domain/src/main/java/com/only4/domain/aggregates/category/Category.java
@@ -75,6 +75,13 @@ public class Category {
     String name;
 
     /**
+     * 引用次数
+     * int
+     */
+    @Column(name = "`ref_count`")
+    Integer refCount;
+
+    /**
      * 逻辑删除
      * tinyint(1)
      */

--- a/only4-KSP-cap4j-domain/src/main/java/com/only4/domain/aggregates/category/meta/CategorySchema.java
+++ b/only4-KSP-cap4j-domain/src/main/java/com/only4/domain/aggregates/category/meta/CategorySchema.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
  * 本文件由[cap4j-ddd-codegen-maven-plugin]生成
  * 警告：请勿手工修改该文件，重新生成会覆盖该文件
  * @author cap4j-ddd-codegen
- * @date 2025/02/15
+ * @date 2025/02/16
  */
 @RequiredArgsConstructor
 public class CategorySchema {
@@ -35,6 +35,11 @@ public class CategorySchema {
          * 分类名
          */
         public static final String name = "name";
+
+        /**
+         * 引用次数
+         */
+        public static final String refCount = "refCount";
 
         /**
          * 逻辑删除
@@ -69,6 +74,14 @@ public class CategorySchema {
      */
     public Schema.Field<String> name() {
         return new Schema.Field<>(root.get("name"), this.criteriaBuilder);
+    }
+
+    /**
+     * 引用次数
+     * int
+     */
+    public Schema.Field<Integer> refCount() {
+        return new Schema.Field<>(root.get("refCount"), this.criteriaBuilder);
     }
 
     /**


### PR DESCRIPTION
feat(category): 增加分类引用次数字段并优化分类相关命令 #22 #66 #34

- 在 Category 模型中添加 refCount 字段，用于记录分类的引用次数
- 更新 CategorySchema 以包含新的 refCount 字段
- 重构 CreateCategoryCmd、DeleteCategoryCmd 和 UpdateCategoryInfoCmd，使用新的分类存在性和引用次数验证注解
- 新增 CategoryExists、CategoryNotExistsWithName 和 CategoryNotRef 验证注解，用于分类相关命令的参数验证